### PR TITLE
楽天カードの新CSVファイルフォーマット対応

### DIFF
--- a/defs/CsvRules.xml
+++ b/defs/CsvRules.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CsvRules>
-  <Version>20140201.01</Version>
+  <Version>20180803.01</Version>
   <Rule>
     <Ident>UltrasoftMoneyLink</Ident>
     <Name>Ultrasoft MoneyLink (Excel⇒CSV書き出し)</Name>
@@ -238,8 +238,8 @@
   <Rule>
     <Ident>RakutenCard</Ident>
     <Name>楽天カード</Name>
-    <FirstLine>"利用日","新規サイン","利用者","利用店名・商品名","支払方法","利用金額","支払手数料","支払総額","支払回数/何回目","当月請求額","翌月繰越残高"</FirstLine>
-    <Format>Date,Dummy,Dummy,Desc,Dummy,Outgo,Dummy,Dummy,Dummy,Dummy,Dummy</Format>
+	<FirstLine>"利用日","利用店名・商品名","利用者","支払方法","利用金額","支払手数料","支払総額",...</FirstLine>
+     <Format>Date,Desc,Dummy,Dummy,Dummy,Dummy,Outgo,Dummy,Dummy,Dummy</Format>
     <Order>Ascent</Order>
   </Rule>
 

--- a/defs/CsvRules.xml
+++ b/defs/CsvRules.xml
@@ -239,7 +239,7 @@
     <Ident>RakutenCard</Ident>
     <Name>楽天カード</Name>
 	<FirstLine>"利用日","利用店名・商品名","利用者","支払方法","利用金額","支払手数料","支払総額",...</FirstLine>
-     <Format>Date,Desc,Dummy,Dummy,Dummy,Dummy,Outgo,Dummy,Dummy,Dummy</Format>
+     <Format>Date,Desc,Dummy,Dummy,Outgo,Dummy,Dummy,Dummy,Dummy,Dummy</Format>
     <Order>Ascent</Order>
   </Rule>
 

--- a/src/CsvAccount.cs
+++ b/src/CsvAccount.cs
@@ -66,7 +66,7 @@ namespace FeliCa2Money
             string line;
             while ((line = mSr.ReadLine()) != null)
             {
-                if (line == mRule.firstLine) return;
+                if (mRule.firstLineCheck(line)) return;
             }
 
             // 先頭行なし

--- a/src/CsvRule.cs
+++ b/src/CsvRule.cs
@@ -37,6 +37,7 @@ namespace FeliCa2Money
         private string mBankId;      // 銀行ID
         private string mName;     // 銀行名
         private string mFirstLine = null; // １行目
+        private bool mIsmFirstLinePartialComp = false; // Length
         private SortOrder mSortOrder; // ソートオーダー
         private bool mIsTSV = false; // TSV かどうか
 
@@ -63,7 +64,32 @@ namespace FeliCa2Money
         public string firstLine
         {
             get { return mFirstLine; }
-            set { mFirstLine = value; }
+            set
+            {
+                string abbreb_key = "...";
+                if (value.EndsWith(abbreb_key) == true){
+                    if (value.Length > abbreb_key.Length){
+                        mIsmFirstLinePartialComp = true;
+                        mFirstLine = value.Substring(0, value.Length - abbreb_key.Length);
+                    }
+                    else{
+                        // throw "error";
+                    }
+                }
+                else {
+                    mFirstLine = value;
+                }
+            }
+        }
+        public bool firstLineCheck(string line)
+        {
+            if (mIsmFirstLinePartialComp){
+                return line.StartsWith(mFirstLine);
+            }
+            if(line == firstLine){
+                return true;
+            }
+            return false;
         }
         public string order
         {

--- a/src/CsvRules.cs
+++ b/src/CsvRules.cs
@@ -149,7 +149,7 @@ namespace FeliCa2Money
         {
             foreach (CsvRule rule in mRules)
             {
-                if (rule.firstLine == firstLine)
+                if (rule.firstLineCheck(firstLine))
                 {
                     return rule;
                 }


### PR DESCRIPTION
変更点
1) 楽天カードの新CSVファイルフォーマットが以下のように月の情報が1行目に入るように変更された。
2) そのため"..."キーワードを作成して、Ruleファイルの<FirstLine>にこのキーワードが定義されていた場合、その場所から行末まで比較対象から外すように変更。

 "利用日","利用店名・商品名","利用者","支払方法","利用金額","支払手数料","支払総額","7月支払金額","8月繰越残高","新規サイン"
